### PR TITLE
Title case for 'Indigenous'

### DIFF
--- a/vocabs/drafts/persons-indigenous-status.ttl
+++ b/vocabs/drafts/persons-indigenous-status.ttl
@@ -12,7 +12,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:provenance "Created for the IDN project, 2025"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "The individual is an indigenous individual" ;
+    skos:definition "The individual is an Indigenous individual" ;
     skos:inScheme cs: ;
     skos:prefLabel "Indigenous"@en ;
 .
@@ -21,7 +21,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:provenance "Created for the IDN project, 2025"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "The individual is not an indigenous individual" ;
+    skos:definition "The individual is not an Indigenous individual" ;
     skos:inScheme cs: ;
     skos:prefLabel "Non-Indigenous"@en ;
 .
@@ -30,7 +30,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     dcterms:provenance "Created for the IDN project, 2025"@en ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "The individual's indigenous status is unknown" ;
+    skos:definition "The individual's Indigenous status is unknown" ;
     skos:inScheme cs: ;
     skos:prefLabel "Indigenous status Unknown"@en ;
 .


### PR DESCRIPTION
updated instances of "indigenous" to "Indigenous" in skos:definition