### PR TITLE
Added missing vocabs in catalogue.ttl

### DIFF
--- a/catalogue.ttl
+++ b/catalogue.ttl
@@ -9,33 +9,38 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:contributor <https://kurrawong.ai> ;
     schema:creator <https://linked.data.gov.au/org/idn> ;
     schema:dateCreated "2022"^^xsd:gYear ;
-    schema:dateModified "2026-05-22"^^xsd:date ;
+    schema:dateModified "2026-06-17"^^xsd:date ;
     schema:description "The Indigenous Data Network's catalogue of reference data" ;
     schema:hasPart
         <https://data.idnau.org/pid/agent-systems> ,
-        <https://data.idnau.org/pid/austlang> ,
-        <https://data.idnau.org/pid/glossary> ,
-        <https://data.idnau.org/pid/licenses> ,
-        <https://data.idnau.org/pid/vocab/aarr> ,
-        <https://data.idnau.org/pid/vocab/care> ,
-        <https://data.idnau.org/pid/vocab/cat-roles> ,
-        <https://data.idnau.org/pid/vocab/idn-th> ,
-        <https://data.idnau.org/pid/vocab/indigeneity> ,
-        <https://data.idnau.org/pid/vocab/org-indigeneity> ,
-        <https://data.idnau.org/pid/vocab/oric> ,
-        <https://data.idnau.org/pid/vocab/persons-indigenous-status> ,
-        <https://data.idnau.org/pid/vocab/policy-types> ,
-        <https://data.idnau.org/pid/vocab/urbanity> ,
-        <https://linked.data.gov.au/def/data-access-rights> ,
-        <https://linked.data.gov.au/def/data-roles> ,
         <https://data.idnau.org/pid/agil> ,
         <https://data.idnau.org/pid/apt> ,
         <https://data.idnau.org/pid/asgs-is> ,
         <https://data.idnau.org/pid/atns> ,
+        <https://data.idnau.org/pid/austlang> ,
         <https://data.idnau.org/pid/capad2020> ,
+        <https://data.idnau.org/pid/glossary> ,
         <https://data.idnau.org/pid/ilm> ,
+        <https://data.idnau.org/pid/licenses> ,
         <https://data.idnau.org/pid/nntt> ,
-        <https://data.idnau.org/pid/nsw-ab> ;
+        <https://data.idnau.org/pid/nsw-ab> ,
+        <https://data.idnau.org/pid/vocab/aarr> ,
+        <https://data.idnau.org/pid/vocab/bc-labels> ,
+        <https://data.idnau.org/pid/vocab/care> ,
+        <https://data.idnau.org/pid/vocab/cat-obj-types> ,
+        <https://data.idnau.org/pid/vocab/cat-roles> ,
+        <https://data.idnau.org/pid/vocab/idn-th> ,
+        <https://data.idnau.org/pid/vocab/indigeneity> ,
+        <https://data.idnau.org/pid/vocab/lc-notices> ,
+        <https://data.idnau.org/pid/vocab/org-indigeneity> ,
+        <https://data.idnau.org/pid/vocab/oric> ,
+        <https://data.idnau.org/pid/vocab/persons-indigenous-status> ,
+        <https://data.idnau.org/pid/vocab/policy-roles> ,
+        <https://data.idnau.org/pid/vocab/policy-types> ,
+        <https://data.idnau.org/pid/vocab/tk-labels> ,
+        <https://data.idnau.org/pid/vocab/urbanity> ,
+        <https://linked.data.gov.au/def/data-access-rights> ,
+        <https://linked.data.gov.au/def/data-roles> ;
     schema:keywords
         "Aboriginal" ,
         "Australia" ,


### PR DESCRIPTION
It seems a few newer vocabs were missing from `catalogue.ttl` so I've added those in. Once this PR is merged they should show up in Prez.